### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/DockerfileDev
+++ b/DockerfileDev
@@ -21,6 +21,7 @@ RUN apt-get update -y \
         python3 \
         python3-distutils \
         python3-nose \
+        python3-setuptools \
         libpq-dev \
         postgresql-server-dev-all \
         libmariadb-dev \

--- a/keamodule/setup.py
+++ b/keamodule/setup.py
@@ -1,6 +1,6 @@
 import os
 import re
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 
 settings = {}


### PR DESCRIPTION
`setuptools` adds additional commands to `setup.py` to generate wheel and egg files.