### PR TITLE
Remove getLease4 from lease_mgr for Kea >= 1.9.4

### DIFF
--- a/keamodule/constants.cc
+++ b/keamodule/constants.cc
@@ -125,7 +125,7 @@ static KeaConstant constants[] = {
     constant(DHO_TCODE),
     constant(DHO_NETINFO_ADDR),
     constant(DHO_NETINFO_TAG),
-    constant(DHO_URL),
+    constant(DHO_V4_CAPTIVE_PORTAL),
     constant(DHO_AUTO_CONFIG),
     constant(DHO_NAME_SERVICE_SEARCH),
     constant(DHO_SUBNET_SELECTION),

--- a/keamodule/lease_mgr.cc
+++ b/keamodule/lease_mgr.cc
@@ -31,6 +31,7 @@ lease_list_from_collection(Lease4Collection &leases) {
     return (list);
 }
 
+#if HAVE_GETLEASE4_METHOD
 static PyObject *
 LeaseMgr_getLease4(LeaseMgrObject *self, PyObject *args, PyObject *kwargs) {
     static const char *kwlist[] = {"addr", "hwaddr", "client_id", "subnet_id", NULL};
@@ -99,6 +100,7 @@ LeaseMgr_getLease4(LeaseMgrObject *self, PyObject *args, PyObject *kwargs) {
         return (0);
     }
 }
+#endif
 
 static PyObject *
 LeaseMgr_getLeases4(LeaseMgrObject *self, PyObject *args, PyObject *kwargs) {
@@ -255,6 +257,7 @@ LeaseMgr_wipeLeases4(LeaseMgrObject *self, PyObject *args) {
     }
 }
 
+#if HAVE_GETLEASE4_METHOD
 static PyMethodDef LeaseMgr_methods[] = {
     {"getLease4", (PyCFunction) LeaseMgr_getLease4, METH_VARARGS | METH_KEYWORDS,
      "Returns an IPv4 lease for specified IPv4 address."},
@@ -270,6 +273,21 @@ static PyMethodDef LeaseMgr_methods[] = {
      "Virtual method which removes specified leases."},
     {0}  // Sentinel
 };
+#else
+static PyMethodDef LeaseMgr_methods[] = {
+    {"getLeases4", (PyCFunction) LeaseMgr_getLeases4, METH_VARARGS | METH_KEYWORDS,
+     "Returns all IPv4 leases for the particular subnet identifier."},
+    {"addLease", (PyCFunction) LeaseMgr_addLease, METH_VARARGS,
+     "Adds an IPv4 lease."},
+    {"deleteLease", (PyCFunction) LeaseMgr_deleteLease, METH_VARARGS,
+     "Deletes a lease."},
+    {"updateLease4", (PyCFunction) LeaseMgr_updateLease4, METH_VARARGS,
+     "Updates IPv4 lease."},
+    {"wipeLeases4", (PyCFunction) LeaseMgr_wipeLeases4, METH_VARARGS,
+     "Virtual method which removes specified leases."},
+    {0}  // Sentinel
+};
+#endif
 
 static void
 LeaseMgr_dealloc(LeaseMgrObject *self) {

--- a/keamodule/setup.py
+++ b/keamodule/setup.py
@@ -15,7 +15,8 @@ def calc_macros():
     m = re.search(r'^#define VERSION "([^"]*)"\n', config_h, re.M)
     if not m:
         raise RuntimeError('could not determine kea version')
-    version = tuple(int(v) for v in m.group(1).split('.'))
+    ver = re.sub('-git', '', m.group(1))
+    version = tuple(int(v) for v in ver.split('.'))
     macros = []
     if version < (1, 7, 1):
         macros.append(('MISSING_GETLEASES4_HOSTNAME', None))
@@ -23,6 +24,8 @@ def calc_macros():
         macros.append(('HAVE_DELETELEASE_ADDR', None))
     if version < (1, 7, 5):
         macros.append(('HAVE_LIBRARYHANDLE_MANAGER_PTR', None))
+    if version < (1, 9, 4):
+        macros.append(('HAVE_GETLEASE4_METHOD', None))
     return macros
 
 


### PR DESCRIPTION
#### SUMMARY

- Added HAVE_GETLEASE4_METHOD macro to include getLeases4 in LeaseMgr methods for Kea versions older than 1.9.4.
- Added step to remove "-git" from version string.

The getLease4 method was removed starting Kea version 1.9.4 ([MR](https://gitlab.isc.org/isc-projects/kea/-/commit/88a9c197883449afb25069b5b32933bf5cc8f034), see ChangeLog excerpt below). This causes the module build to exit with error for those Kea versions. 

```
1851.	[func]		fdupont
	Removed methods fetching leases by both client identifier
	and hardware addresses from the API.
	(Gitlab #1540)
```

#### ISSUE TYPE

- Build error for Kea versions 1.9.4 and newer.

#### COMPONENT NAME

M       keamodule/lease_mgr.cc
M       keamodule/setup.py

#### ADDITIONAL INFORMATION

Tested module build and basic DHCP lease with Kea 2.0.0.